### PR TITLE
Duplicate 'Version' description of plugin info file format generates a exception.

### DIFF
--- a/package/yapsy/PluginManager.py
+++ b/package/yapsy/PluginManager.py
@@ -80,9 +80,9 @@ Here is an example of what such a file should contain::
       [Documentation]
       Description = What my plugin broadly does
       Author = My very own name
-      Version = 0.1
-      Website = My very own website
       Version = the_version_number_of_the_plugin
+      Website = My very own website
+      
       
  
 .. note:: From such plugin descriptions, the ``PluginManager`` will


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "core.py", line 9, in <module>
    simplePluginManager.collectPlugins()
  File "/usr/lib/python3.3/site-packages/yapsy/PluginManager.py", line 527, in collectPlugins
    self.locatePlugins()
  File "/usr/lib/python3.3/site-packages/yapsy/PluginManager.py", line 442, in locatePlugins
    self._candidates, npc = self.getPluginLocator().locatePlugins()
  File "/usr/lib/python3.3/site-packages/yapsy/PluginFileLocator.py", line 429, in locatePlugins
    plugin_info = self._getInfoForPluginFromAnalyzer(analyzer, dirpath, filename)
  File "/usr/lib/python3.3/site-packages/yapsy/PluginFileLocator.py", line 383, in _getInfoForPluginFromAnalyzer
    plugin_info_dict,config_parser = analyzer.getInfosDictFromPlugin(dirpath, filename)
  File "/usr/lib/python3.3/site-packages/yapsy/PluginFileLocator.py", line 261, in getInfosDictFromPlugin
    infos, config_parser = self._extractBasicPluginInfo(dirpath, filename)
  File "/usr/lib/python3.3/site-packages/yapsy/PluginFileLocator.py", line 240, in _extractBasicPluginInfo
    if config_parser.has_section("Documentation"):
AttributeError: 'NoneType' object has no attribute 'has_section'
```
