### PR TITLE
Allow plugins to be run in separate process

### DIFF
--- a/package/doc/IMultiprocessChildPlugin.rst
+++ b/package/doc/IMultiprocessChildPlugin.rst
@@ -1,0 +1,10 @@
+=============
+IMultiprocessChildPlugin
+=============
+
+.. toctree::
+   :maxdepth: 2
+
+.. automodule:: yapsy.IMultiprocessChildPlugin
+   :members:
+   :undoc-members:

--- a/package/doc/MultiprocessPluginManager.rst
+++ b/package/doc/MultiprocessPluginManager.rst
@@ -1,0 +1,12 @@
+=============
+MultiprocessPluginManager
+=============
+
+.. toctree::
+   :maxdepth: 2
+
+
+.. automodule:: yapsy.MultiprocessPluginManager
+   :members:
+   :undoc-members:   
+

--- a/package/doc/MultiprocessPluginProxy.rst
+++ b/package/doc/MultiprocessPluginProxy.rst
@@ -1,0 +1,10 @@
+=============
+MultiprocessPluginProxy
+=============
+
+.. toctree::
+   :maxdepth: 2
+
+.. automodule:: yapsy.MultiprocessPluginProxy
+   :members:
+   :undoc-members:

--- a/package/test/plugins/SimpleMultiprocessPlugin.py
+++ b/package/test/plugins/SimpleMultiprocessPlugin.py
@@ -1,0 +1,20 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+"""
+A simple multiprocessed plugin that echoes the content received to the parent
+"""
+
+from yapsy.IMultiprocessChildPlugin import IMultiprocessChildPlugin
+
+class SimpleMultiprocessPlugin(IMultiprocessChildPlugin):
+	"""
+	Only trigger the expected test results.
+	"""
+
+	def __init__(self, parent_pipe):
+		IMultiprocessChildPlugin.__init__(self, parent_pipe=parent_pipe)
+
+	def run(self):
+		content_from_parent = self.parent_pipe.recv()
+		self.parent_pipe.send("{}|echo_from_child".format(content_from_parent))

--- a/package/test/plugins/SimpleMultiprocessPlugin.py
+++ b/package/test/plugins/SimpleMultiprocessPlugin.py
@@ -17,4 +17,4 @@ class SimpleMultiprocessPlugin(IMultiprocessChildPlugin):
 
 	def run(self):
 		content_from_parent = self.parent_pipe.recv()
-		self.parent_pipe.send("{}|echo_from_child".format(content_from_parent))
+		self.parent_pipe.send("{0}|echo_from_child".format(content_from_parent))

--- a/package/test/plugins/simplemultiprocessplugin.multiprocess-plugin
+++ b/package/test/plugins/simplemultiprocessplugin.multiprocess-plugin
@@ -1,0 +1,9 @@
+[Core]
+Name = Simple Multiprocess Plugin
+Module = SimpleMultiprocessPlugin
+
+[Documentation]
+Author = Pierre-Yves Langlois
+Version = 0.1
+Description = A minimal plugin to test multiprocessing
+Copyright = 2015

--- a/package/test/test_All.py
+++ b/package/test/test_All.py
@@ -25,7 +25,7 @@ from . import test_FilterPlugin
 from . import test_ErrorInPlugin
 from . import test_PluginFileLocator
 from . import test_PluginInfo
-
+from . import test_SimpleMultiprocessPlugin
 
 # add them to a common test suite
 MainTestSuite = unittest.TestSuite(
@@ -39,5 +39,6 @@ MainTestSuite = unittest.TestSuite(
 		test_ErrorInPlugin.suite,
 		test_PluginFileLocator.suite,
 		test_PluginInfo.suite,
+		test_SimpleMultiprocessPlugin.suite,
 		])
 

--- a/package/test/test_SimpleMultiprocessPlugin.py
+++ b/package/test/test_SimpleMultiprocessPlugin.py
@@ -1,0 +1,45 @@
+#!/usr/bin/python
+# -*- coding: utf-8; tab-width: 4; indent-tabs-mode: t; python-indent: 4 -*-
+
+import unittest
+import os 
+
+from yapsy.PluginManager import PluginManager
+from yapsy.MultiprocessPluginManager import MultiprocessPluginManager
+
+class SimpleMultiprocessTestCase(unittest.TestCase):
+	"""
+	Test the correct loading of a multiprocessed plugin as well as basic
+	communication.
+	"""
+	
+	def setUp(self):
+		"""
+		init
+		"""
+		# create the plugin manager
+		self.mpPluginManager = MultiprocessPluginManager(directories_list=[
+				os.path.join(
+					os.path.dirname(os.path.abspath(__file__)),"plugins")],
+				plugin_info_ext="multiprocess-plugin")
+		# load the plugins that may be found
+		self.mpPluginManager.collectPlugins()
+		# Will be used later
+		self.plugin_info = None
+
+	def testUpAndRunning(self):
+		"""
+		Test if the plugin is loaded and if the communication pipe is properly setuped.
+		"""
+		for plugin in self.mpPluginManager.getAllPlugins():
+			content_from_parent = "hello-from-parent"
+			content_from_child = False
+			plugin.plugin_object.child_pipe.send(content_from_parent)
+			if plugin.plugin_object.child_pipe.poll(5):
+				content_from_child = plugin.plugin_object.child_pipe.recv()
+			self.assertEqual(content_from_child, "{}|echo_from_child".format(content_from_parent))
+
+
+suite = unittest.TestSuite([
+		unittest.TestLoader().loadTestsFromTestCase(SimpleMultiprocessTestCase),
+		])

--- a/package/test/test_SimpleMultiprocessPlugin.py
+++ b/package/test/test_SimpleMultiprocessPlugin.py
@@ -37,7 +37,7 @@ class SimpleMultiprocessTestCase(unittest.TestCase):
 			plugin.plugin_object.child_pipe.send(content_from_parent)
 			if plugin.plugin_object.child_pipe.poll(5):
 				content_from_child = plugin.plugin_object.child_pipe.recv()
-			self.assertEqual(content_from_child, "{}|echo_from_child".format(content_from_parent))
+			self.assertEqual(content_from_child, "{0}|echo_from_child".format(content_from_parent))
 
 
 suite = unittest.TestSuite([

--- a/package/yapsy/IMultiprocessChildPlugin.py
+++ b/package/yapsy/IMultiprocessChildPlugin.py
@@ -29,17 +29,19 @@ API
 ===
 """
 
+from multiprocessing import Process
 from yapsy.IPlugin import IPlugin
 
-class IMultiprocessChildPlugin(IPlugin):
+
+class IMultiprocessChildPlugin(IPlugin, Process):
 	"""
 	Base class for multiprocessed plugin.
 	"""
 
-	def __init__(self, parent_pipe=None):
-		IPlugin.__init__(self)
+	def __init__(self, parent_pipe):
 		self.parent_pipe = parent_pipe
-		self.run()
+		IPlugin.__init__(self)
+		Process.__init__(self)
 
 	def run(self):
 		"""

--- a/package/yapsy/IMultiprocessChildPlugin.py
+++ b/package/yapsy/IMultiprocessChildPlugin.py
@@ -1,0 +1,48 @@
+#!/usr/bin/python
+# -*- coding: utf-8; tab-width: 4; indent-tabs-mode: t; python-indent: 4 -*-
+
+
+"""
+Role
+====
+
+Defines the basic interfaces for multiprocessed plugins.
+
+Extensibility
+=============
+
+In your own software, you'll probably want to build derived classes of
+the ``IMultiprocessChildPlugin`` class as it is a mere interface with no specific
+functionality.
+
+Your software's plugins should then inherit your very own plugin class
+(itself derived from ``IMultiprocessChildPlugin``).
+
+Override the run method to include your code. Use the self.parent_pipe to send
+and receive data with the parent process or create your own communication
+mecanism.
+
+Where and how to code these plugins is explained in the section about
+the :doc:`PluginManager`.
+
+API
+===
+"""
+
+from yapsy.IPlugin import IPlugin
+
+class IMultiprocessChildPlugin(IPlugin):
+	"""
+	Base class for multiprocessed plugin.
+	"""
+
+	def __init__(self, parent_pipe=None):
+		IPlugin.__init__(self)
+		self.parent_pipe = parent_pipe
+		self.run()
+
+	def run(self):
+		"""
+		Override this method in your implementation
+		"""
+		return

--- a/package/yapsy/MultiprocessPluginManager.py
+++ b/package/yapsy/MultiprocessPluginManager.py
@@ -50,7 +50,7 @@ class MultiprocessPluginManager(PluginManager):
 		"""
 		instanciated_element = MultiprocessPluginProxy()
 		parent_pipe, child_pipe = mproc.Pipe()
-		instanciated_element.proc = mproc.Process(target=element, args=(child_pipe,))
+		instanciated_element.proc = element(child_pipe)
 		instanciated_element.child_pipe = parent_pipe
 		instanciated_element.proc.start()
 		return instanciated_element

--- a/package/yapsy/MultiprocessPluginManager.py
+++ b/package/yapsy/MultiprocessPluginManager.py
@@ -1,0 +1,57 @@
+#!/usr/bin/python
+# -*- coding: utf-8; tab-width: 4; indent-tabs-mode: t; python-indent: 4 -*-
+
+"""
+Role
+====
+
+Defines a plugin manager that runs all plugins in separate process
+linked by pipes.
+
+
+API
+===
+"""
+
+import multiprocessing as mproc
+
+from yapsy.IMultiprocessChildPlugin import IMultiprocessChildPlugin
+from yapsy.MultiprocessPluginProxy import MultiprocessPluginProxy
+from yapsy.PluginManager import  PluginManager
+
+
+class MultiprocessPluginManager(PluginManager):
+	"""
+	Subclass of the PluginManager that runs each plugin in a different process
+	"""
+
+	def __init__(self,
+				 categories_filter={"Default":IMultiprocessChildPlugin},
+				 directories_list=None,
+				 plugin_info_ext=None,
+				 plugin_locator=None):
+		"""
+		init
+		"""
+		PluginManager.__init__(self,
+								 categories_filter=categories_filter,
+								 directories_list=directories_list,
+								 plugin_info_ext=plugin_info_ext,
+								 plugin_locator=plugin_locator)
+
+	def instanciateElement(self, element):
+		"""
+		This method instanciate each plugin in a new process and link it to
+		the parent with a pipe.
+
+		In the parent process context, the plugin's class is replaced by the ``MultiprocessPluginProxy``
+		class that hold the information about the child process and the pipe to communicate with it. See
+		:doc:`IMultiprocessChildPlugin`
+		"""
+		instanciated_element = MultiprocessPluginProxy()
+		parent_pipe, child_pipe = mproc.Pipe()
+		instanciated_element.proc = mproc.Process(target=element, args=(child_pipe,))
+		instanciated_element.child_pipe = parent_pipe
+		instanciated_element.proc.start()
+		return instanciated_element
+

--- a/package/yapsy/MultiprocessPluginProxy.py
+++ b/package/yapsy/MultiprocessPluginProxy.py
@@ -19,6 +19,7 @@ API
 
 from yapsy.IPlugin import IPlugin
 
+
 class MultiprocessPluginProxy(IPlugin):
 	"""
 	This class contains two members that are initialized by the :doc:`MultiprocessPluginManager`.

--- a/package/yapsy/MultiprocessPluginProxy.py
+++ b/package/yapsy/MultiprocessPluginProxy.py
@@ -26,9 +26,9 @@ class MultiprocessPluginProxy(IPlugin):
 
 	self.proc is a reference that holds the multiprocessing.Process instance of the child process.
 
-	self.child_pipe is a reference that holds the multiprocessing.Poll instance to communicate with the child.
+	self.child_pipe is a reference that holds the multiprocessing.Pipe instance to communicate with the child.
 	"""
 	def __init__(self):
 		IPlugin.__init__(self)
 		self.proc = None		# This attribute holds the multiprocessing.Process instance
-		self.child_pipe = None  # This attribute holds the multiprocessing.Poll instance
+		self.child_pipe = None  # This attribute holds the multiprocessing.Pipe instance

--- a/package/yapsy/MultiprocessPluginProxy.py
+++ b/package/yapsy/MultiprocessPluginProxy.py
@@ -1,0 +1,33 @@
+#!/usr/bin/python
+# -*- coding: utf-8; tab-width: 4; indent-tabs-mode: t; python-indent: 4 -*-
+
+
+"""
+Role
+====
+
+The ``MultiprocessPluginProxy`` is instanciated by the MultiprocessPluginManager to replace the real implementation
+that is run in a different process.
+
+You cannot access your plugin directly from the parent process. You should use the child_pipe to communicate
+with your plugin. The `MultiprocessPluginProxy`` role is to keep reference of the communication pipe to the
+child process as well as the process informations.
+
+API
+===
+"""
+
+from yapsy.IPlugin import IPlugin
+
+class MultiprocessPluginProxy(IPlugin):
+	"""
+	This class contains two members that are initialized by the :doc:`MultiprocessPluginManager`.
+
+	self.proc is a reference that holds the multiprocessing.Process instance of the child process.
+
+	self.child_pipe is a reference that holds the multiprocessing.Poll instance to communicate with the child.
+	"""
+	def __init__(self):
+		IPlugin.__init__(self)
+		self.proc = None		# This attribute holds the multiprocessing.Process instance
+		self.child_pipe = None  # This attribute holds the multiprocessing.Poll instance

--- a/package/yapsy/PluginManager.py
+++ b/package/yapsy/PluginManager.py
@@ -508,7 +508,7 @@ class PluginManager(object):
 							if candidate_infofile not in self._category_file_mapping[current_category]:
 								# we found a new plugin: initialise it and search for the next one
 								if not plugin_info_reference:
-									plugin_info.plugin_object = element()
+									plugin_info.plugin_object = self.instanciateElement(element)
 									plugin_info_reference = plugin_info
 								plugin_info.categories.append(current_category)
 								self.category_mapping[current_category].append(plugin_info_reference)
@@ -517,6 +517,12 @@ class PluginManager(object):
 		# don't need to take up the space
 		delattr(self, '_candidates')
 		return processed_plugins
+
+	def instanciateElement(self, element):
+		"""
+		Override this method to customize how plugins are instanciated
+		"""
+		return element()
 
 	def collectPlugins(self):
 		"""

--- a/package/yapsy/__init__.py
+++ b/package/yapsy/__init__.py
@@ -53,7 +53,7 @@ should get you a fully working plugin management system::
 
 """
 
-__version__="1.10.423"
+__version__="1.10.423.py_9"
 
 # tell epydoc that the documentation is in the reStructuredText format
 __docformat__ = "restructuredtext en"


### PR DESCRIPTION
Hi yapsy team,

Thanks for yapsy, it is a great software, very well designed, light and easy to use!

I would like to use yapsy for my project but I need each plugin to run in separate process. So I created a set of classes that achieve this goal. I tried to code it as minimalistic as possible to keep the maintenance simple.

What do you think of this feature?

Thanks!

Pierre-Yves Langlois