### PR TITLE
fix PluginFileLocator __init__

### DIFF
--- a/package/yapsy/PluginFileLocator.py
+++ b/package/yapsy/PluginFileLocator.py
@@ -332,7 +332,7 @@ class PluginFileLocator(IPluginLocator):
 		self._analyzers = analyzers      # analyzers used to locate plugins
 		if self._analyzers is None:
 			self._analyzers = [PluginFileAnalyzerWithInfoFile("info_ext")]
-		self._default_plugin_info_cls = PluginInfo
+		self._default_plugin_info_cls = plugin_info_cls  # NOT PluginInfo
 		self._plugin_info_cls_map = {}
 		self._max_size = 1e3*1024 # in octets (by default 1 Mo)
 		self.recursive = True


### PR DESCRIPTION
should assign plugin_info_cls to _default_plugin_info_cls, not
PluginInfo