### PR TITLE
Changes to use importlib.abc.Loader, if importlib is available

### DIFF
--- a/package/yapsy/PluginManager.py
+++ b/package/yapsy/PluginManager.py
@@ -129,7 +129,7 @@ API
 import sys
 import os
 try:
-	import importlib as imp
+	import importlib.abc.Loader as imp
 except ImportError:
 	import imp
 

--- a/package/yapsy/PluginManager.py
+++ b/package/yapsy/PluginManager.py
@@ -128,7 +128,10 @@ API
 
 import sys
 import os
-import imp
+try:
+	import importlib as imp
+except ImportError:
+	import imp
 
 from yapsy import log
 from yapsy import NormalizePluginNameForModuleName


### PR DESCRIPTION
This adds a try to use importlib, if available. All the tests pass with the new code.