### PR TITLE
Replace Python Regex strings as raw strings

### DIFF
--- a/package/test/test_FilterPlugin.py
+++ b/package/test/test_FilterPlugin.py
@@ -14,7 +14,7 @@ class testFilter(FilteredPluginManager):
 	Test filter class.
 	Refused to load plugins whose Name starts with 'C'.
 	"""
-	_bannednames = re.compile("^C")
+	_bannednames = re.compile(r"^C")
 
 	def isPluginOk(self,info):
 		return not self._bannednames.match(info.name)

--- a/package/yapsy/__init__.py
+++ b/package/yapsy/__init__.py
@@ -70,7 +70,7 @@ PLUGIN_NAME_FORBIDEN_STRING=";;"
 """
 
 import re
-RE_NON_ALPHANUM = re.compile("\W")
+RE_NON_ALPHANUM = re.compile(r"\W")
 
 
 def NormalizePluginNameForModuleName(pluginName):


### PR DESCRIPTION
As per latest Python documentation:
The `re` module will require raw strings for regular expressions:
https://docs.python.domainunion.de/3/library/re.html
